### PR TITLE
Clarify explanation of command chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Skipping to the end, here is the line that builds our builder docker image and t
 
 which does the following:
 
-* Builds a 'builder' docker image using the Dockerfile in the current directory (docker build -t builder .)
-* Runs the 'builder' docker which builds the sources in the current directory and outputs them as a tar stream (docker run builder)
-* Builds an image called 'dockerception' from the tar stream which contains a Dockerfile and the binary (docker build -t dockerception -)
+* Builds a 'builder' docker image using the Dockerfile in the current directory (`docker build -t builder .`)
+* Runs the 'builder' docker which builds the sources in the current directory and outputs a Dockerfile and binary as a tar stream (`docker run builder`)
+* Builds a runtime image (from the above tar stream) called 'dockerception' (`... | docker build -t dockerception -`)
 
 The Dockerfile for the builder looks as follows:
 


### PR DESCRIPTION
Excellent project, but there's an ambiguous sentence or two in the README that had me very confused. I looked at this yesterday and couldn't understand the following passage:

> Builds an image called 'dockerception' from the tar stream which contains a Dockerfile and the binary

I originally parsed this as "an image called 'dockerception' … contains a Dockerfile and the binary" rather than "the tar stream … contains a Dockerfile and the binary". Only this morning after playing with the project could I figure out that the Dockerfile and binary were part of the tar stream, not the resulting image.

I think the included patch clarifies the wording.
